### PR TITLE
Build Auto Scheduler using Maven and POM.xml

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,2 @@
 #!/usr/bin/env bash
-
-rm ./code/src/org/txstate/auto_scheduler/*.class
-rm ./code/src/org/txstate/auto_scheduler/*.jar
-javac -d ./code/bin ./code/src/org/txstate/auto_scheduler/*.java
-jar -cvfm ./code/bin/org/txstate/auto_scheduler/auto_scheduler.jar ./code/src/org/txstate/auto_scheduler/MANIFEST.MF ./code/bin/org/txstate/auto_scheduler/*.class
+mvn package

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.txstate.auto_scheduler</groupId>
+  <artifactId>auto_scheduler</artifactId>
+  <version>1.0</version>
+
+  <name>auto_scheduler</name>
+  <!-- FIXME change it to the project's website -->
+  <url>https://github.com/samaniehsan/auto-scheduler</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.4</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>./code/src/org/txstate/auto_scheduler</sourceDirectory>
+    <pluginManagement>      <!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+          <configuration>
+            <archive>
+              <manifestFile>${project.build.sourceDirectory}/MANIFEST.MF</manifestFile>
+              <manifest>
+                <addClasspath>true</addClasspath>
+                <mainClass>org.txstate.auto_scheduler.Main</mainClass>
+              </manifest>
+            </archive>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>


### PR DESCRIPTION
Maven helps us pull down and manage dependencies such as 
```java
import org.apache.commons.csv.CSVFormat;
import org.apache.commons.csv.CSVParser;
import org.apache.commons.csv.CSVRecord;
```
Tested using `mvn 3.6.0`

you can run `mvn compile` or `mvn package` to build the jar file

# How to use it
![mvn package](https://user-images.githubusercontent.com/15373896/55688016-74da9200-5939-11e9-874f-300bdb4e0458.gif)


## required environment variables 
requires environment variable `M2_HOME` to be set to `C:\Software\apache-maven-3.6.0`
and also environment variable `JAVA_HOME` to be set to `C:\Program Files\Java\jdk-11.0.2` 

@Keggeraider @vjara98 @HernandezDerek @brominger 