### PR TITLE
Remove out folder

### DIFF
--- a/out/production/auto-scheduler/org/txstate/auto_scheduler/MANIFEST.MF
+++ b/out/production/auto-scheduler/org/txstate/auto_scheduler/MANIFEST.MF
@@ -1,1 +1,0 @@
-Main-Class: org.txstate.auto_scheduler.Main


### PR DESCRIPTION
The build target directory should not be checked in.
also maven uses the default of target directory so it is easier just
having target directory.

@Keggeraider @vjara98 @HernandezDerek @brominger 

follow up to #30