### PR TITLE
fix malformed csv file

### DIFF
--- a/src/main/resources/data/classes/psychology.csv
+++ b/src/main/resources/data/classes/psychology.csv
@@ -29,5 +29,5 @@ PSY3313,Psychology_of_Adulthood_and_Aging,Psychology,PSY1300
 PSY3315,Abnormal_Psychology,Psychology,PSY1300
 PSY3316,Personality_Psychology,Psychology,PSY1300
 PSY4342,Learning_and_Memory,Psychology,PSY1300
-PSY3402,Experimental_and_Research_Methods,PSY2301 
+PSY3402,Experimental_and_Research_Methods,Psychology,PSY2301 
 PSY4391,History_and_Theory,Psychology,PSY3402


### PR DESCRIPTION
This fixes a bug for scheduling student.
`z12345679`

because this csv file had a missing column we would get an exception while reading prereq column.

@brominger @Keggeraider @vjara98 @HernandezDerek 